### PR TITLE
Updated binary_sensor

### DIFF
--- a/custom_components/satel_integra/binary_sensor.py
+++ b/custom_components/satel_integra/binary_sensor.py
@@ -40,7 +40,7 @@ async def async_setup_platform(
         zone_type = device_config_data[CONF_ZONE_TYPE]
         zone_name = device_config_data[CONF_ZONE_NAME]
         device = SatelIntegraBinarySensor(
-            controller, zone_num, zone_name, zone_type, SIGNAL_ZONES_UPDATED
+            controller, zone_num, zone_name, zone_type, CONF_ZONES, SIGNAL_ZONES_UPDATED
         )
         devices.append(device)
 
@@ -50,7 +50,12 @@ async def async_setup_platform(
         zone_type = device_config_data[CONF_ZONE_TYPE]
         zone_name = device_config_data[CONF_ZONE_NAME]
         device = SatelIntegraBinarySensor(
-            controller, zone_num, zone_name, zone_type, SIGNAL_OUTPUTS_UPDATED
+            controller,
+            zone_num,
+            zone_name,
+            zone_type,
+            CONF_OUTPUTS,
+            SIGNAL_OUTPUTS_UPDATED,
         )
         devices.append(device)
 
@@ -63,10 +68,17 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
     _attr_should_poll = False
 
     def __init__(
-        self, controller, device_number, device_name, zone_type, react_to_signal
+        self,
+        controller,
+        device_number,
+        device_name,
+        zone_type,
+        sensor_type,
+        react_to_signal,
     ):
         """Initialize the binary_sensor."""
         self._device_number = device_number
+        self._attr_unique_id = f"satel_{sensor_type}_{device_number}"
         self._name = device_name
         self._zone_type = zone_type
         self._state = 0
@@ -80,11 +92,10 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
                 self._state = 1
             else:
                 self._state = 0
+        elif self._device_number in self._satel.violated_zones:
+            self._state = 1
         else:
-            if self._device_number in self._satel.violated_zones:
-                self._state = 1
-            else:
-                self._state = 0
+            self._state = 0
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, self._react_to_signal, self._devices_updated
@@ -97,10 +108,11 @@ class SatelIntegraBinarySensor(BinarySensorEntity):
         return self._name
 
     @property
-    def icon(self):
+    def icon(self) -> str | None:
         """Icon for device by its type."""
         if self._zone_type is BinarySensorDeviceClass.SMOKE:
             return "mdi:fire"
+        return None
 
     @property
     def is_on(self):


### PR DESCRIPTION
Updated binary_sensor by merging changes from HomeAssistant core Satel integration code.
This prevents https://www.home-assistant.io/faq/unique_id error and thus enables entities to be assigned to areas etc.