### PR TITLE
Fixed import of AlarmState

### DIFF
--- a/custom_components/satel_integra/alarm_control_panel.py
+++ b/custom_components/satel_integra/alarm_control_panel.py
@@ -5,7 +5,7 @@ import asyncio
 from collections import OrderedDict
 import logging
 
-from satel_integra.satel_integra import AlarmState
+from satel_integra2.satel_integra import AlarmState
 
 import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature


### PR DESCRIPTION
It appears that integration is trying to import AlarmState from original `satel_integra` integration. On my HA instance this results in alarm status updates never being recognized because values `satel_integra2.satel_integra.AsyncSatel.partition_states` map is populated using keys of Enum type `satel_integra2.satel_integra.AlarmState`, however HA integration tries to compare them to `satel_integra.satel_integra.AlarmState` Enum values, which will always result in no match, because values are of different types from different Python libraries.

My HA instance initially had original Satel integration (with original satel_integra Python lib) installed, but I later switched to the "Alternative" to use encrypted communications. So both `satel_integra` and `satel_integra2` Python libraries were available and imports succeeded, but integration never updated alarm status panel states for partition because of this. No idea how this could have ever worked for anyone else.